### PR TITLE
Fixes #3 - Load opcache.ini earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Composer, of course!
 
 ## Why do you use an `app` user instead of root?
 
-TL;DR; Security. 
+TL;DR; Security.
 
 Read up on it here: [Processes in containers should not run as root](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b)
 
@@ -67,12 +67,12 @@ Or if you like to use docker-compose:
         image: ashsmith/php:7.2-cli
         volumes:
           - ./src:/var/www/html:delegated
-      
+
       phpfpm:
         image: ashsmith/php:7.2-fpm
         volumes:
           - ./src:/var/www/html:delegated
-      
+
       nginx:
         image: ashsmith/nginx:latest-phpfpm
         environment:
@@ -91,6 +91,12 @@ Then:
 Want to run one of commands?
 
     docker-compose run --rm cli composer install
+
+# OpCache
+
+opcache is enabled by default!
+
+For local development I recommend mounting a new php .ini file to disable opcache.
 
 
 ## Credit

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -46,8 +46,8 @@ RUN ["chown", "-R", "app:app", "/var/www", "/var/www/html", "/var/www/bin"]
 # A few sensible defaults.
 ADD fpm/config/www.conf /usr/local/etc/php-fpm.d/
 ADD fpm/config/php-fpm.conf /usr/local/etc/
-ADD fpm/config/opcache.ini /usr/local/etc/php/conf.d/zz-opcache.ini
-ADD fpm/config/opcache.blacklist /usr/local/etc/php/conf.d/zz-opcache.blacklist
+ADD fpm/config/opcache.ini /usr/local/etc/php/conf.d/aa-opcache.ini
+ADD fpm/config/opcache.blacklist /usr/local/etc/php/conf.d/opcache.blacklist
 USER app:app
 
 WORKDIR /var/www/html


### PR DESCRIPTION
Renaming mounted opcache file to aa-opcache.ini to ensure it is loaded sooner.

This means you can override its settings by adding a xx-mychanges.ini to ensure it is loaded later.