### PR TITLE
Improved opcache configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
       - checkout:
           path: ~/ashsmith-docker-php
       - run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
+          echo "$DOCKER_PASS" | docker login -u $DOCKER_USER --password-stdin
           export BRANCH=''
           if [ "$CIRCLE_BRANCH" != "master" ]; then
             export BRANCH="-${CIRCLE_BRANCH}"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Available tags:
 - ashsmith/php:7.2-cli-alpine
 
 Deprecated tags (only alpine is being actively developed):
-- ashsmith/php:7.1-fpm 
+- ashsmith/php:7.1-fpm
 - ashsmith/php:7.1-cli
 - ashsmith/php:7.2-fpm
 - ashsmith/php:7.2-cli
@@ -102,7 +102,9 @@ Want to run one of commands?
 
 opcache is enabled by default!
 
-For local development I recommend mounting a new php .ini file to explicitly disable opcache.
+For local development I recommend setting the `$PHP_OPCACHE_VALIDATE_TIMESTAMPS` environment variable to a value of `1`. For production, leave it as `0`.
+
+    docker run -e PHP_OPCACHE_VALIDATE_TIMESTAMPS=1 ashsmith/php:7.2-fpm sh
 
 
 ## Credit

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -3,6 +3,11 @@ FROM php:${VERSION}-cli-alpine
 ARG PHP_EXTENSIONS
 ARG XDEBUG
 
+ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0" \
+    PHP_OPCACHE_MAX_ACCELERATED_FILES="16000" \
+    PHP_OPCACHE_MEMORY_CONSUMPTION="192" \
+    PHP_OPCACHE_MAX_WASTED_PERCENTAGE="10"
+
 # Install dependencies
 RUN apk add --no-cache \
     vim git openssh zip wget ca-certificates \
@@ -17,6 +22,8 @@ RUN apk add --no-cache \
   docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
   docker-php-ext-install $PHP_EXTENSIONS && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY fpm/config/opcache.ini /usr/local/etc/php/conf.d/aa-opcache.ini
 
 RUN if [ "$XDEBUG" = "1" ]; then apk add --no-cache $PHPIZE_DEPS && pecl install -o -f xdebug && docker-php-ext-enable xdebug; fi
 

--- a/cli/config/opcache.ini
+++ b/cli/config/opcache.ini
@@ -7,9 +7,17 @@ opcache.max_accelerated_files   = ${PHP_OPCACHE_MAX_ACCELERATED_FILES}
 opcache.max_wasted_percentage   = ${PHP_OPCACHE_MAX_WASTED_PERCENTAGE}
 opcache.fast_shutdown           = 1
 
+opcache.use_cwd             = 1
 opcache.validate_timestamps = ${PHP_OPCACHE_VALIDATE_TIMESTAMPS}
 opcache.revalidate_freq     = 0
+opcache.revalidate_path     = 1
+
+; Applications might use comments in class reflections
+opcache.save_comments = 1
+opcache.load_comments = 1
 
 ; Log & blacklist paths
+opcache.log_verbosity_level = 1
 opcache.error_log           = /proc/self/fd/2
 opcache.blacklist_filename  = /usr/local/etc/php/conf.d/opcache.blacklist
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       context: .
       args:
         VERSION: "7.1"
-        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath pcntl mcrypt"
+        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath pcntl mcrypt opcache"
         FLAVOUR: alpine
       dockerfile: cli/Dockerfile
 
@@ -29,7 +29,7 @@ services:
       context: .
       args:
         VERSION: "7.2"
-        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath"
+        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache"
         FLAVOUR: alpine
       dockerfile: cli/Dockerfile
 
@@ -47,7 +47,7 @@ services:
       context: .
       args:
         VERSION: "7.3"
-        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath"
+        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache"
         FLAVOUR: alpine
       dockerfile: cli/Dockerfile
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -3,6 +3,11 @@ FROM php:${VERSION}-fpm-alpine
 ARG XDEBUG
 ARG PHP_EXTENSIONS
 
+ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0" \
+    PHP_OPCACHE_MAX_ACCELERATED_FILES="16000" \
+    PHP_OPCACHE_MEMORY_CONSUMPTION="192" \
+    PHP_OPCACHE_MAX_WASTED_PERCENTAGE="10"
+
 # Install dependencies
 RUN apk add --no-cache \
     mysql-client \
@@ -21,8 +26,8 @@ RUN adduser -D -g 1000 -u 1000 -h /var/www -s /bin/bash app && \
   chown -R app:app /var/www /var/www/html /var/www/bin
 
 # A few sensible defaults.
-ADD fpm/config/php-fpm.conf /usr/local/etc/
-ADD fpm/config/opcache.ini /usr/local/etc/php/conf.d/aa-opcache.ini
+COPY fpm/config/php-fpm.conf /usr/local/etc/
+COPY fpm/config/opcache.ini /usr/local/etc/php/conf.d/aa-opcache.ini
 RUN touch /usr/local/etc/php/conf.d/opcache.blacklist
 USER app:app
 


### PR DESCRIPTION
With this new opcache configuration we better optimise caching, speeding up performance.

Instead of disabling all of opcache for local development we can set the `$PHP_OPCACHE_VALIDATE_TIMESTAMPS` environment variable to `1` instead. Which means cache will invalidate when a file has changed.

This will keep PHP performant on local development, but also still allow cache invalidation easily.